### PR TITLE
Add left margin on assertion description text.

### DIFF
--- a/src/aura/greased_AssertionCommon/greased_AssertionCommon.cmp
+++ b/src/aura/greased_AssertionCommon/greased_AssertionCommon.cmp
@@ -21,7 +21,7 @@
                     <h2>
                         <lightning:icon iconName="{!'action:'+(v.result?'approval':'close')}" size="xx-small"/>
                         <a href="javascript:void(0);" class="slds-text-link--reset">
-                            <span class="slds-text-heading--small">{!v.description}</span>
+                            <span class="slds-text-heading--small slds-m-left_small">{!v.description}</span>
                         </a>
                     </h2>
                 </div>


### PR DESCRIPTION
I've added left margin on assertion description text because of:
https://i.imgur.com/32lIWuG.png

I've changed it to:
https://i.imgur.com/SBqzszc.png

What do you think?